### PR TITLE
Modified spanish pronouns and added catalan ones

### DIFF
--- a/pronomial/__init__.py
+++ b/pronomial/__init__.py
@@ -12,11 +12,13 @@ class PronomialCoreferenceSolver:
         PLURAL_NOUN_TAG = ['NOUN']
         SUBJ_TAG = ['NOUN']
         WITH = WITH_FOLLOWUP = THAT = THAT_FOLLOWUP = []
+        NEUTRAL_WORDS = []
 
         if lang.startswith("en"):
             from pronomial.lang.en import NOUN_TAG_EN, PLURAL_NOUN_TAG_EN, \
                 PRONOUNS_EN, PRONOUN_TAG_EN, SUBJ_TAG_EN, JJ_TAG_EN, WITH_EN,\
-                GENDERED_WORDS_EN, WITH_FOLLOWUP_EN, THAT_EN, THAT_FOLLOWUP_EN
+                GENDERED_WORDS_EN, WITH_FOLLOWUP_EN, THAT_EN, \
+                THAT_FOLLOWUP_EN, NEUTRAL_WORDS_EN
             GENDERED_WORDS = GENDERED_WORDS_EN
             NOUN_TAG = NOUN_TAG_EN
             SUBJ_TAG = SUBJ_TAG_EN
@@ -28,6 +30,7 @@ class PronomialCoreferenceSolver:
             WITH_FOLLOWUP = WITH_FOLLOWUP_EN
             THAT = THAT_EN
             THAT_FOLLOWUP = THAT_FOLLOWUP_EN
+            NEUTRAL_WORDS = NEUTRAL_WORDS_EN
         elif lang.startswith("pt"):
             from pronomial.lang.pt import PRONOUNS_PT, GENDERED_WORDS_PT
             GENDERED_WORDS = GENDERED_WORDS_PT
@@ -69,18 +72,21 @@ class PronomialCoreferenceSolver:
                 idz = 0
 
             if t in NOUN_TAG:
-                gender = predict_gender(w, prev_w, lang=lang)
-                if w in PRONOUNS["female"] or\
-                        w.lower() in GENDERED_WORDS["female"]:
-                    prev_names["female"].append(w)
-                elif w in PRONOUNS["male"] or \
-                        w.lower() in GENDERED_WORDS["male"]:
-                    prev_names["male"].append(w)
-                elif w[0].isupper() or prev_t in ["DET"]:
-                    prev_names[gender].append(w)
-                prev_names["neutral"].append(w)
-                prev_names["subject"].append(w)
-                prev_names["subject_gender"] = gender
+                if prev_w in NEUTRAL_WORDS:
+                    prev_names["neutral"].append(w)
+                else:
+                    gender = predict_gender(w, prev_w, lang=lang)
+                    if w in PRONOUNS["female"] or\
+                            w.lower() in GENDERED_WORDS["female"]:
+                        prev_names["female"].append(w)
+                    elif w in PRONOUNS["male"] or \
+                            w.lower() in GENDERED_WORDS["male"]:
+                        prev_names["male"].append(w)
+                    elif w[0].isupper() or prev_t in ["DET"]:
+                        prev_names[gender].append(w)
+                    prev_names["neutral"].append(w)
+                    prev_names["subject"].append(w)
+                    prev_names["subject_gender"] = gender
             elif t in SUBJ_TAG:
                 prev_names["subject"].append(w)
                 gender = predict_gender(w, prev_w, lang=lang)

--- a/pronomial/__init__.py
+++ b/pronomial/__init__.py
@@ -44,6 +44,9 @@ class PronomialCoreferenceSolver:
             raise NotImplementedError
 
         tags = pos_tag(sentence, lang=lang)
+        pron_list = [p for k, p in PRONOUNS.items()]
+        flatten = lambda l: [item for sublist in l for item in sublist]
+        pron_list = flatten(pron_list)
 
         prev_names = {
             "male": [],
@@ -87,10 +90,9 @@ class PronomialCoreferenceSolver:
                     prev_names["female"].append(w)
                 if gender == "male":
                     prev_names["male"].append(w)
-            elif t in PRONOUN_TAG or any(w in items
+            elif (t in PRONOUN_TAG and w.lower() in pron_list) or any(w in items
                                          for k, items in PRONOUNS.items()):
                 w = w.lower()
-
                 if w in PRONOUNS["male"]:
                     if prev_names["male"]:
                         candidates.append((idx, w, prev_names["male"][idz]))

--- a/pronomial/lang/en.py
+++ b/pronomial/lang/en.py
@@ -22,6 +22,8 @@ JJ_TAG_EN = ['JJ']
 PLURAL_NOUN_TAG_EN = ['NNS', 'NNPS']
 SUBJ_TAG_EN = ["nsubj", "dobj"]
 
+NEUTRAL_WORDS_EN = ["in"]  # if word before Noun -> neutral not male nor female
+
 GENDERED_WORDS_EN = {
     "female": ["mom", "mother", "woman", "women", "aunt", "girl", "girls",
                "sister", "sisters", "mothers"],

--- a/pronomial/lang/es.py
+++ b/pronomial/lang/es.py
@@ -7,23 +7,54 @@ from string import punctuation
 from random import shuffle
 
 PRONOUNS_ES = {
-    'male': ['ello', "lo", 'ellos', "los"],
-    'female': ['ella', "la", 'ellas', "las"],
-    'first': ['yo', 'me', 'mí', 'mío', "mía"],
-    'neutral': ["tú", "vos", "te", "le", "se", "l'", "él"],
-    'plural': ['nosotras', 'nosotros', 'nuestros', 'nuestras', 'vuestro',
-               'vuestra', "ellos", "ellas"]
+    'male': ['el', "los", 'ello', 'vosotros', 'nosotros', 'este', 'ese',
+             'aquel','uno', 'alguno', 'ninguno', 'poco', 'escaso', 'mucho',
+             'demasiado', 'todo', 'otro', 'mismo', 'tanto', 'tan', 'mío',
+             'tuyo', 'suyo'],
+    'female': ['la', "las", 'ella', 'vosotras', 'nosotras','esta', 'esa',
+               'aquella', 'una', 'alguna', 'ninguna', 'poca', 'escasa',
+               'mucha', 'demasiada', 'toda', 'otra', 'misma', 'tanta',
+               'alguien', 'nadie', 'cualquiera', 'quienquiera', 'demás',
+               'mía', 'tuya', 'suya'],
+    'first': ['yo', 'me', 'mí', 'mío', 'conmigo', 'nos', 'míos', 'mías',
+              'nuestro', 'nuestra',''],
+    'neutral': ['tú', 'vos', 'usted', 'le', 'se', 'te', 'mí', 'conmigo',
+                'esto', 'eso', 'aquello', 'lo', 'cuál', 'cuánto', 'qué',
+                'cómo', 'quién', 'quiénes', 'uno', 'algo', 'nada', 'poco',
+                'escaso', 'mucho', 'demasiado', 'todo', 'otro', 'mismo',
+                'tanto', 'os', 'que', 'cual', 'quien', 'cuyo', 'donde'],
+    'plural': ['nosotras', 'nosotros', 'nuestros', 'nuestras', 'vuestros',
+               'vuestras', 'suyo', 'vosotros', 'vosotras', 'ellos', 'ellas',
+               'estos', 'esos', 'aquellos','estas', 'esas', 'aquellas',
+               'unos', 'algunos', 'ningunos', 'pocos', 'escasos', 'muchos',
+               'demasiados', 'todos', 'varios', 'otros', 'mismos', 'tantos',
+               'unas', 'algunas', 'ningunas', 'pocas', 'escasas', 'muchas',
+               'demasiadas', 'todas', 'varias', 'otras', 'mismas', 'tantas',
+               'cualquiera', 'quienquiera', 'demás', 'ustedes', 'mis', 'tus',
+               'sus']
 }
 
 # special cases, word2gender mappings
 GENDERED_WORDS_ES = {
-    "female": [],
-    "male": []
+    "female": ['mamá', 'mamás', 'madre', 'madres', 'mujer', 'mujeres', 'tía',
+               'tías', 'prima', 'primas', 'chica', 'chicas', 'hermana',
+               'hermanas', 'sobrina', 'sobrinas', 'nieta', 'nietas'],
+    "male": ['papá', 'papás', 'padre', 'padres', 'hombre', 'hombres', 'tío',
+               'tíos', 'primo', 'primos', 'chico', 'chicos', 'hermano',
+               'hermanos', 'sobrino', 'sobrinos', 'nieto', 'nietos']
 }
 
 # context rules for gender
-MALE_DETERMINANTS_ES = ["lo", "los", "ello", "ellos"]
-FEMALE_DETERMINANTS_ES = ["la", "las", "ella", "ellas"]
+MALE_DETERMINANTS_ES = ['el', "los", 'ello', 'vosotros', 'nosotros', 'este',
+                        'ese', 'aquel','uno', 'alguno', 'ninguno', 'poco',
+                        'escaso', 'mucho', 'demasiado', 'todo', 'otro',
+                        'mismo', 'tanto', 'tan', 'mío', 'tuyo', 'suyo',
+                        ]
+FEMALE_DETERMINANTS_ES = ['la', "las", 'ella', 'vosotras', 'nosotras','esta',
+                         'esa', 'aquella', 'una', 'alguna', 'ninguna', 'poca',
+                         'escasa', 'mucha', 'demasiada', 'toda', 'otra',
+                         'misma', 'tanta', 'alguien', 'nadie', 'cualquiera',
+                         'quienquiera', 'demás', 'mía', 'tuya', 'suya']
 
 
 def train_es_tagger(path):

--- a/pronomial/lang/es.py
+++ b/pronomial/lang/es.py
@@ -17,7 +17,7 @@ PRONOUNS_ES = {
                'alguien', 'nadie', 'cualquiera', 'quienquiera', 'demás',
                'mía', 'tuya', 'suya'],
     'first': ['yo', 'me', 'mí', 'mío', 'conmigo', 'nos', 'míos', 'mías',
-              'nuestro', 'nuestra',''],
+              'nuestro', 'nuestra'],
     'neutral': ['tú', 'vos', 'usted', 'le', 'se', 'te', 'mí', 'conmigo',
                 'esto', 'eso', 'aquello', 'lo', 'cuál', 'cuánto', 'qué',
                 'cómo', 'quién', 'quiénes', 'uno', 'algo', 'nada', 'poco',

--- a/readme.md
+++ b/readme.md
@@ -24,3 +24,19 @@ replace_corefs("London has been a major settlement for two millennia. "
 "London was founded by the Romans , Romans named London Londinium ."
 """
 ```
+
+## About
+
+Pronomial will work fine for short sentences and should be safe to use in 
+the context of simple things like intent parsing, but it tends to fail 
+horribly in long sentences.
+
+It you want a proper coreference resolution library I suggest you check out
+[neuralcoref](https://github.com/huggingface/neuralcoref)
+
+Pronomial should not be used in production most of the
+time, it is intended as baseline and an experiment on how well this
+task can be solved using only heuristics. 
+
+
+Keep an eye on this section for future benchmarks

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='pronomial',
-    version='0.0.4',
+    version='0.0.5a1',
     packages=['pronomial', 'pronomial.lang'],
     url='https://github.com/OpenJarbas/pronomial',
     license='apache-2.0',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='pronomial',
-    version='0.0.4a3',
+    version='0.0.4',
     packages=['pronomial', 'pronomial.lang'],
     url='https://github.com/OpenJarbas/pronomial',
     license='apache-2.0',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='pronomial',
-    version='0.0.4a1',
+    version='0.0.4a3',
     packages=['pronomial', 'pronomial.lang'],
     url='https://github.com/OpenJarbas/pronomial',
     license='apache-2.0',

--- a/test/test_en.py
+++ b/test/test_en.py
@@ -20,6 +20,11 @@ class TestCorefEN(unittest.TestCase):
 
     def test_male(self):
         self.assertEqual(
+            replace_corefs("Joe was talking to Bob and told him to go home "
+                           "because he was drunk"),
+            "Joe was talking to Bob and told Bob to go home because Bob was drunk"
+        )
+        self.assertEqual(
             replace_corefs("Jack is one of the top candidates in "
                            "the elections. His ideas are unique compared to "
                            "Bob's."),
@@ -127,13 +132,21 @@ class TestCorefEN(unittest.TestCase):
             "Turn on the light and change light to blue"
         )
 
-    def test_ambiguous(self):
-        # understandable mistakes
+    def test_mixed(self):
+        self.assertEqual(
+            replace_corefs("My sister has a dog, She loves him!"),
+            "My sister has a dog , sister loves dog !"
+        )
+
+    def test_neutral_postag(self):
+        # in {noun}-> in == IN -> {noun} == neutral
+
+        # "Arendelle" is recognized as a location because of "in", otherwise
+        # it would be tagged as a female name and be used instead of Elsa
         self.assertEqual(
             replace_corefs(
                 "Chris is very handsome. He is Australian. Elsa lives in Arendelle. He likes her."),
-            "Chris is very handsome . Chris is Australian . Elsa lives in Arendelle . Chris likes Arendelle ."
-            # "Chris is very handsome . Chris is Australian . Elsa lives in Arendelle . Chris likes Elsa ."
+            "Chris is very handsome . Chris is Australian . Elsa lives in Arendelle . Chris likes Elsa ."
         )
 
     def test_with(self):

--- a/test/test_pt.py
+++ b/test/test_pt.py
@@ -8,26 +8,49 @@ class TestCorefPT(unittest.TestCase):
         self.lang = "pt"
 
     def test_female(self):
+        # female only
         self.assertEqual(
             replace_corefs("A Ana gosta de cães. Ela tem dois",
                            lang=self.lang),
             "A Ana gosta de cães . Ana tem dois"
         )
+        # female x2
+        self.assertEqual(
+            replace_corefs("a Ana disse á Maria que ela tem bom gosto",
+                           lang=self.lang),
+            "a Ana disse á Maria que Maria tem bom gosto"
+        )
+        # male + female
+        self.assertEqual(
+            replace_corefs("o João disse ao Joaquim que gosta da Ana. Ela "
+                           "é bonita",
+                           lang=self.lang),
+            "o João disse ao Joaquim que gosta da Ana . Ana é bonita"
+        )
 
     def test_male(self):
+        # male only
         self.assertEqual(
             replace_corefs("o João gosta de gatos. Ele tem quatro",
                            lang=self.lang),
             "o João gosta de gatos . João tem quatro"
         )
+        # male x2
+        self.assertEqual(
+            replace_corefs("o João disse ao Joaquim que ele está gordo",
+                           lang=self.lang),
+            "o João disse ao Joaquim que Joaquim está gordo"
+        )
 
     def test_plural(self):
+        # female noun from wordlist
         self.assertEqual(
             replace_corefs("As mulheres da ribeira do sado é que é, "
                            "Elas lavram a terra com as unhas dos pés",
                            lang=self.lang),
             "As mulheres da ribeira do sado é que é , mulheres lavram a terra com as unhas dos pés"
         )
+        # male noun from wordlist
         self.assertEqual(
             replace_corefs("Os americanos foram á lua. Eles são fodidos",
                            lang=self.lang),


### PR DESCRIPTION
On this PR, I've slightly modified the spanish pronouns and added the catalan ones, besides, in catalan there exist the "weak pronouns" (a particle in front or behind the verb) which can give more information about the noun, like number or gender.
So the `predict_gender_ca()` function has been modified to add weak pronouns like `-les`, `-los`, etc to reflect that.

Unlike spanish, portuguese or other romance languages, catalan female words usually ends with an `a`, but male words, yet many ends with an `e`, they really can be finish with almost any letter (i.e.: llapis (pencil), armari (wardrobe), disc (disk), cub (cube), and many, many others), so I've deleted the variable `_MALE_ENDINGS_CA`.

There are but, some corner cases not covered yet, like gendered plurals. Unlike in spanish or portuguese, which most plurals just adds an `s`, in catalan female endings usually -not always, though- transforms the final `a` into `es` (so "taula" (table) becomes "taules") and male words sometimes add an "s" ("cub" (cube) would be "cubs") while others change their ending to another particle (disc (disk) becomes "discos" or even "discs"). And besides that, male words ending with an `e`(remember, male words usually ends with an `e`) their plural also ends in `es`, just like female ones.
So, this later part needs a lot more work.