### PR TITLE
Modified spanish pronouns and added catalan ones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.venv
+.vscode
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode
 
 __pycache__
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .venv
 .vscode
 
+__pycache__

--- a/pronomial/lang/es.py
+++ b/pronomial/lang/es.py
@@ -7,23 +7,54 @@ from string import punctuation
 from random import shuffle
 
 PRONOUNS_ES = {
-    'male': ['ello', "lo", 'ellos', "los"],
-    'female': ['ella', "la", 'ellas', "las"],
-    'first': ['yo', 'me', 'mí', 'mío', "mía"],
-    'neutral': ["tú", "vos", "te", "le", "se", "l'", "él"],
-    'plural': ['nosotras', 'nosotros', 'nuestros', 'nuestras', 'vuestro',
-               'vuestra', "ellos", "ellas"]
+    'male': ['el', "los", 'ello', 'vosotros', 'nosotros', 'este', 'ese',
+             'aquel','uno', 'alguno', 'ninguno', 'poco', 'escaso', 'mucho',
+             'demasiado', 'todo', 'otro', 'mismo', 'tanto', 'tan', 'mío',
+             'tuyo', 'suyo'],
+    'female': ['la', "las", 'ella', 'vosotras', 'nosotras','esta', 'esa',
+               'aquella', 'una', 'alguna', 'ninguna', 'poca', 'escasa',
+               'mucha', 'demasiada', 'toda', 'otra', 'misma', 'tanta',
+               'alguien', 'nadie', 'cualquiera', 'quienquiera', 'demás',
+               'mía', 'tuya', 'suya'],
+    'first': ['yo', 'me', 'mí', 'mío', 'conmigo', 'nos', 'míos', 'mías',
+              'nuestro', 'nuestra',''],
+    'neutral': ['tú', 'vos', 'usted', 'le', 'se', 'te', 'mí', 'conmigo',
+                'esto', 'eso', 'aquello', 'lo', 'cuál', 'cuánto', 'qué',
+                'cómo', 'quién', 'quiénes', 'uno', 'algo', 'nada', 'poco',
+                'escaso', 'mucho', 'demasiado', 'todo', 'otro', 'mismo',
+                'tanto', 'os', 'que', 'cual', 'quien', 'cuyo', 'donde'],
+    'plural': ['nosotras', 'nosotros', 'nuestros', 'nuestras', 'vuestros',
+               'vuestras', 'suyo', 'vosotros', 'vosotras', 'ellos', 'ellas',
+               'estos', 'esos', 'aquellos','estas', 'esas', 'aquellas',
+               'unos', 'algunos', 'ningunos', 'pocos', 'escasos', 'muchos',
+               'demasiados', 'todos', 'varios', 'otros', 'mismos', 'tantos',
+               'unas', 'algunas', 'ningunas', 'pocas', 'escasas', 'muchas',
+               'demasiadas', 'todas', 'varias', 'otras', 'mismas', 'tantas',
+               'cualquiera', 'quienquiera', 'demás', 'ustedes', 'mis', 'tus',
+               'sus']
 }
 
 # special cases, word2gender mappings
 GENDERED_WORDS_ES = {
-    "female": [],
-    "male": []
+    "female": ['mamá', 'mamás', 'madre', 'madres', 'mujer', 'mujeres', 'tía',
+               'tías', 'prima', 'primas', 'chica', 'chicas', 'hermana',
+               'hermanas', 'sobrina', 'sobrinas', 'nieta', 'nietas'],
+    "male": ['papá', 'papás', 'padre', 'padres', 'hombre', 'hombres', 'tío',
+               'tíos', 'primo', 'primos', 'chico', 'chicos', 'hermano',
+               'hermanos', 'sobrino', 'sobrinos', 'nieto', 'nietos']
 }
 
 # context rules for gender
-MALE_DETERMINANTS_ES = ["lo", "los", "ello", "ellos"]
-FEMALE_DETERMINANTS_ES = ["la", "las", "ella", "ellas"]
+MALE_DETERMINANTS_ES = ['el', "los", 'ello', 'vosotros', 'nosotros', 'este',
+                        'ese', 'aquel','uno', 'alguno', 'ninguno', 'poco',
+                        'escaso', 'mucho', 'demasiado', 'todo', 'otro',
+                        'mismo', 'tanto', 'tan', 'mío', 'tuyo', 'suyo',
+                        ]
+FEMALE_DETERMINANTS_ES = ['la', "las", 'ella', 'vosotras', 'nosotras','esta',
+                         'esa', 'aquella', 'una', 'alguna', 'ninguna', 'poca',
+                         'escasa', 'mucha', 'demasiada', 'toda', 'otra',
+                         'misma', 'tanta', 'alguien', 'nadie', 'cualquiera',
+                         'quienquiera', 'demás', 'mía', 'tuya', 'suya']
 
 
 def train_es_tagger(path):

--- a/pronomial/lang/es.py
+++ b/pronomial/lang/es.py
@@ -7,23 +7,54 @@ from string import punctuation
 from random import shuffle
 
 PRONOUNS_ES = {
-    'male': ['ello', "lo", 'ellos', "los"],
-    'female': ['ella', "la", 'ellas', "las"],
-    'first': ['yo', 'me', 'mí', 'mío', "mía"],
-    'neutral': ["tú", "vos", "te", "le", "se", "l'", "él"],
-    'plural': ['nosotras', 'nosotros', 'nuestros', 'nuestras', 'vuestro',
-               'vuestra', "ellos", "ellas"]
+    'male': ['el', "los", 'ello', 'vosotros', 'nosotros', 'este', 'ese',
+             'aquel','uno', 'alguno', 'ninguno', 'poco', 'escaso', 'mucho', 
+             'demasiado', 'todo', 'otro', 'mismo', 'tanto', 'tan', 'mío',
+             'tuyo', 'suyo'],
+    'female': ['la', "las", 'ella', 'vosotras', 'nosotras','esta', 'esa',
+               'aquella', 'una', 'alguna', 'ninguna', 'poca', 'escasa', 
+               'mucha', 'demasiada', 'toda', 'otra', 'misma', 'tanta',
+               'alguien', 'nadie', 'cualquiera', 'quienquiera', 'demás',
+               'mía', 'tuya', 'suya'],
+    'first': ['yo', 'me', 'mí', 'mío', 'conmigo', 'nos', 'míos', 'mías',
+              'nuestro', 'nuestra',''],
+    'neutral': ['tú', 'vos', 'usted', 'le', 'se', 'te', 'mí', 'conmigo',
+                'esto', 'eso', 'aquello', 'lo', 'cuál', 'cuánto', 'qué', 
+                'cómo', 'quién', 'quiénes', 'uno', 'algo', 'nada', 'poco',
+                'escaso', 'mucho', 'demasiado', 'todo', 'otro', 'mismo',
+                'tanto', 'os', 'que', 'cual', 'quien', 'cuyo', 'donde'],
+    'plural': ['nosotras', 'nosotros', 'nuestros', 'nuestras', 'vuestros',
+               'vuestras', 'suyo', 'vosotros', 'vosotras', 'ellos', 'ellas',
+               'estos', 'esos', 'aquellos','estas', 'esas', 'aquellas', 
+               'unos', 'algunos', 'ningunos', 'pocos', 'escasos', 'muchos', 
+               'demasiados', 'todos', 'varios', 'otros', 'mismos', 'tantos',
+               'unas', 'algunas', 'ningunas', 'pocas', 'escasas', 'muchas', 
+               'demasiadas', 'todas', 'varias', 'otras', 'mismas', 'tantas',
+               'cualquiera', 'quienquiera', 'demás', 'ustedes', 'mis', 'tus',
+               'sus']
 }
 
 # special cases, word2gender mappings
 GENDERED_WORDS_ES = {
-    "female": [],
-    "male": []
+    "female": ['mamá', 'mamás', 'madre', 'madres', 'mujer', 'mujeres', 'tía',
+               'tías', 'prima', 'primas', 'chica', 'chicas', 'hermana', 
+               'hermanas', 'sobrina', 'sobrinas', 'nieta', 'nietas'],
+    "male": ['papá', 'papás', 'padre', 'padres', 'hombre', 'hombres', 'tío',
+               'tíos', 'primo', 'primos', 'chico', 'chicos', 'hermano', 
+               'hermanos', 'sobrino', 'sobrinos', 'nieto', 'nietos']
 }
 
 # context rules for gender
-MALE_DETERMINANTS_ES = ["lo", "los", "ello", "ellos"]
-FEMALE_DETERMINANTS_ES = ["la", "las", "ella", "ellas"]
+MALE_DETERMINANTS_ES = ['el', "los", 'ello', 'vosotros', 'nosotros', 'este', 
+                        'ese', 'aquel','uno', 'alguno', 'ninguno', 'poco', 
+                        'escaso', 'mucho', 'demasiado', 'todo', 'otro', 
+                        'mismo', 'tanto', 'tan', 'mío', 'tuyo', 'suyo',
+                        ]
+FEMALE_DETERMINANTS_ES = ['la', "las", 'ella', 'vosotras', 'nosotras','esta',
+                         'esa', 'aquella', 'una', 'alguna', 'ninguna', 'poca',
+                         'escasa', 'mucha', 'demasiada', 'toda', 'otra', 
+                         'misma', 'tanta', 'alguien', 'nadie', 'cualquiera', 
+                         'quienquiera', 'demás', 'mía', 'tuya', 'suya']
 
 
 def train_es_tagger(path):

--- a/pronomial/lang/es.py
+++ b/pronomial/lang/es.py
@@ -7,17 +7,17 @@ from string import punctuation
 from random import shuffle
 
 PRONOUNS_ES = {
-    'male': ['el', "los", 'ello', 'vosotros', 'nosotros', 'este', 'ese',
+    'male': ['el', "los", 'ello', 'vuestro', 'nuestro', 'este', 'ese',
              'aquel','uno', 'alguno', 'ninguno', 'poco', 'escaso', 'mucho', 
              'demasiado', 'todo', 'otro', 'mismo', 'tanto', 'tan', 'mío',
              'tuyo', 'suyo'],
-    'female': ['la', "las", 'ella', 'vosotras', 'nosotras','esta', 'esa',
+    'female': ['la', "las", 'ella', 'vuestra', 'nuestra','esta', 'esa',
                'aquella', 'una', 'alguna', 'ninguna', 'poca', 'escasa', 
                'mucha', 'demasiada', 'toda', 'otra', 'misma', 'tanta',
                'alguien', 'nadie', 'cualquiera', 'quienquiera', 'demás',
                'mía', 'tuya', 'suya'],
     'first': ['yo', 'me', 'mí', 'mío', 'conmigo', 'nos', 'míos', 'mías',
-              'nuestro', 'nuestra',''],
+              'nuestro', 'nuestra', 'nosotros'],
     'neutral': ['tú', 'vos', 'usted', 'le', 'se', 'te', 'mí', 'conmigo',
                 'esto', 'eso', 'aquello', 'lo', 'cuál', 'cuánto', 'qué', 
                 'cómo', 'quién', 'quiénes', 'uno', 'algo', 'nada', 'poco',


### PR DESCRIPTION
On this PR, I've slightly modified the spanish pronouns and added the catalan ones, besides, in catalan there exist the "weak pronouns" (a particle in front or behind the verb) which can give more information about the noun, like number or gender.
So the `predict_gender_ca()` function has been modified to add weak pronouns like `-les`, `-los`, etc to reflect that.

Unlike spanish, portuguese or other romance languages, catalan female words usually ends with an `a`, but male words, yet many ends with an `e`, they really can be finish with almost any letter (i.e.: llapis (pencil), armari (wardrobe), disc (disk), cub (cube), and many, many others), so I've deleted the variable `_MALE_ENDINGS_CA`.

There are but, some corner cases not covered yet, like gendered plurals. Unlike in spanish or portuguese, which most plurals just adds an `s`, in catalan female endings usually -not always, though- transforms the final `a` into `es` (so "taula" (table) becomes "taules") and male words sometimes add an "s" ("cub" (cube) would be "cubs") while others change their ending to another particle (disc (disk) becomes "discos" or even "discs"). And besides that, male words ending with an `e`(remember, male words usually ends with an `e`) their plural also ends in `es`, just like female ones.
So, this later part needs a lot more work.